### PR TITLE
U96V2: fix SD card voltage mode in device tree

### DIFF
--- a/recipes-bsp/device-tree/files/u96v2-sbc/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/u96v2-sbc/system-bsp.dtsi
@@ -90,6 +90,12 @@
    /delete-node/wifi@2;
 };
 
+// Set 3.3 V for SD Card
+&sdhci0 {
+   no-1-8-v;
+   disable-wp;
+};
+
 &i2c1 {
 	status = "okay";
 	clock-frequency = <100000>;


### PR DESCRIPTION
See #15 