### PR TITLE
Add choose correct webserver to start. Change python server port to 80

### DIFF
--- a/recipes-apps/python-webserver/files/launch_server.sh
+++ b/recipes-apps/python-webserver/files/launch_server.sh
@@ -56,10 +56,13 @@ cd /home/root/webserver
 echo "Export and initialize the GPIO"
 source ./setup_gpio.sh
 
-echo "Set web page location:"
-killall -9 httpd
-httpd -h /home/root/webserver
+if [ -f ./server.py ]; then
+    echo "Start the Python webserver in the background"
+    python3 ./server.py &
+else
+    echo "Set web page location:"
+    killall -9 httpd
+    httpd -h /home/root/webserver
+fi
 
-echo "Start the Python webserver in the background"
-python3 ./server.py &
 

--- a/recipes-apps/python-webserver/files/pz/server.py
+++ b/recipes-apps/python-webserver/files/pz/server.py
@@ -52,7 +52,7 @@ elif len(sys.argv) > 1:
     PORT = int(sys.argv[1])
     I = ""
 else:
-    PORT = 8000
+    PORT = 80
     I = ""
 
 class ServerHandler(http.server.SimpleHTTPRequestHandler):


### PR DESCRIPTION
On the uz/mz/pz the server is expected to start only a python server, however two webservers were launched. An apache webserver with httpd and the python webserver. Serving on ports 80 and 8000 respectively. The problem is the apache webserver on port 80 doesn't handle any webpage interaction with the system. So the set LED does not work. This would be the default webpage to go to as it's on port 80. I don't think we need to include the httpd portion and just move the python server to port 80.