### PR TITLE
Fix/add root ssh config

### DIFF
--- a/recipes-core/images/avnet-image-full.inc
+++ b/recipes-core/images/avnet-image-full.inc
@@ -230,6 +230,7 @@ COMMON_FEATURES_append_zynqmp = "\
 "
 
 COMMON_FEATURES_append_zynq = "\
+        debug-tweaks \
         hwcodecs \
         ssh-server-openssh \
 "

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -129,6 +129,7 @@ COMMON_FEATURES_append_zynqmp = "\
 "
 
 COMMON_FEATURES_append_zynq = "\
+        debug-tweaks \
         hwcodecs \
         ssh-server-dropbear \
 "

--- a/recipes-core/openssh/openssh_%.bbappend
+++ b/recipes-core/openssh/openssh_%.bbappend
@@ -1,0 +1,5 @@
+do_install_append() {
+    echo "===== PISS ====="
+    echo "PermitRootLogin yes" >> ${D}${sysconfdir}/ssh/sshd_config
+}
+

--- a/recipes-core/openssh/openssh_%.bbappend
+++ b/recipes-core/openssh/openssh_%.bbappend
@@ -1,5 +1,0 @@
-do_install_append() {
-    echo "===== PISS ====="
-    echo "PermitRootLogin yes" >> ${D}${sysconfdir}/ssh/sshd_config
-}
-


### PR DESCRIPTION
Openssh does not allow root login by default. Enabling debug-tweaks modifies the sshd configuration to allow root login. It also adds a post install log on first boot.