### PR TITLE
u96v2_sbc: recipes-utils: update ultra96-radio-leds.sh

### DIFF
--- a/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
+++ b/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
@@ -11,8 +11,6 @@
 ### END INIT INFO
 
 SYS_GPIO_FOLDER=/sys/class/gpio
-WIFI_LED=502
-BT_LED=501
 LED_ON=1
 LED_OFF=0
 
@@ -32,6 +30,10 @@ do
 	fi
 done
 
+if [ -z "$BT_LED" ]; then
+	echo "ERROR: /etc/init.d/ultra96-radio-leds.sh : Could not find axi gpio device with base address 0xa0050000 !"
+	exit 1
+fi
 
 DESC="ultra96-radio-leds.sh will turn the WiFi and Bluetooth LEDs on and off on Ultra96"
 

--- a/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
+++ b/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
@@ -11,10 +11,30 @@
 ### END INIT INFO
 
 SYS_GPIO_FOLDER=/sys/class/gpio
-WIFI_LED=506
-BT_LED=505
+WIFI_LED=498
+BT_LED=497
 LED_ON=1
 LED_OFF=0
+
+for gpiochip in `ls /sys/class/gpio | grep gpiochip`
+do
+	label=$(cat /sys/class/gpio/$gpiochip/label)
+	base=$(cat /sys/class/gpio/$gpiochip/base)
+	ngpio=$(cat /sys/class/gpio/$gpiochip/ngpio)
+
+	#echo $gpiochip : $label $base $ngpio
+
+	#if [ $ngpio == 2 ]; then
+	if [[ "$label" == *"a0050000.gpio"* ]]; then
+		((BT_LED=base+0))
+		((WIFI_LED=base+1))
+
+		echo "   WIFI LED GPIO = $WIFI_LED"
+		echo "   BT   LED GPIO = $BT_LED"
+   
+		break
+	fi
+done
 
 
 DESC="ultra96-radio-leds.sh will turn the WiFi and Bluetooth LEDs on and off on Ultra96"

--- a/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
+++ b/recipes-utils/ultra96-radio-leds/files/ultra96-radio-leds.sh
@@ -11,20 +11,16 @@
 ### END INIT INFO
 
 SYS_GPIO_FOLDER=/sys/class/gpio
-WIFI_LED=498
-BT_LED=497
+WIFI_LED=502
+BT_LED=501
 LED_ON=1
 LED_OFF=0
 
-for gpiochip in `ls /sys/class/gpio | grep gpiochip`
+for gpiochip in `ls $SYS_GPIO_FOLDER | grep gpiochip`
 do
-	label=$(cat /sys/class/gpio/$gpiochip/label)
-	base=$(cat /sys/class/gpio/$gpiochip/base)
-	ngpio=$(cat /sys/class/gpio/$gpiochip/ngpio)
+	label=$(cat $SYS_GPIO_FOLDER/$gpiochip/label)
+	base=$(cat $SYS_GPIO_FOLDER/$gpiochip/base)
 
-	#echo $gpiochip : $label $base $ngpio
-
-	#if [ $ngpio == 2 ]; then
 	if [[ "$label" == *"a0050000.gpio"* ]]; then
 		((BT_LED=base+0))
 		((WIFI_LED=base+1))


### PR DESCRIPTION
u96v2_sbc: recipes-utils: update ultra96-radio-leds.sh to determine /sys/class/gpio/gpio# for wifi/bluetooth leds based on base address of axi_gpio core (0xA0050000).