### PR TITLE
Removing sw4 entry, There are multiple things wrong with it

### DIFF
--- a/recipes-bsp/device-tree/files/u96v2-sbc/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/u96v2-sbc/system-bsp.dtsi
@@ -15,13 +15,6 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 		autorepeat;
-		sw4 {
-			label = "sw4";
-			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_POWER>; /* down */
-			wakeup-source;
-			autorepeat;
-		};
 	};
 
 	iio-hwmon {


### PR DESCRIPTION
 - gpio23 doesn't go to power button sw4, it goes to user switch sw1.
 - This entry prevents the user from using the sw1 since the gpio is already resevered
 - This doesn't work as a power switch. sw4 already works as the power switch anyway