### PR TITLE
New scheme to capture 'petalinux way' of configuring rootfs

### DIFF
--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -1,6 +1,11 @@
 require recipes-core/images/petalinux-image-common.inc
 
-# append what's already defined by petalinux (build/conf/plnxtool.conf)
+# append what is already defined by petalinux (build/conf/plnxtool.conf)
+# this will include what the user adds or removes via "petalinux-config -c rootfs"
+IMAGE_INSTALL_append= "\
+        ${IMAGE_INSTALL_pn-petalinux-image-minimal} \
+"
+
 IMAGE_INSTALL_append_zynq = "\
         haveged \
         mtd-utils \
@@ -10,10 +15,16 @@ IMAGE_INSTALL_append_zynq = "\
         udev-extraconf \
 "
 
-# remove unnecessary packages to fit in qspi
+# remove unnecessary packages found in
+# ${IMAGE_INSTALL_pn-petalinux-image-minimal} (build/conf/plnxtool.conf)
+# that make the OS image too large to fit in QSPI
 IMAGE_INSTALL_remove_zynq = "\
+        bridge-utils \
+        can-utils \
         htop \
         meson \
+        openssh-sftp-server \
+        pciutils \
 "
 
 IMAGE_INSTALL_append_zynqmp = "\


### PR DESCRIPTION
Changes to rootfs config to allow "petalinux way" of adding custom apps or customizing the rootfs.  Tested with MiniZed.