### PR TITLE
recipes-bsp: u-boot: use u-boot without debug info

### DIFF
--- a/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
@@ -1,1 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+UBOOTELF_NODTB_BINARY = "u-boot.elf"


### PR DESCRIPTION
modify UBOOTELF_NODTB_BINARY variable to use u-boot.elf instead of
u-boot (which contains all debug symbols)