### PR TITLE
Fix missing overrides for u96v2-sbc machine

### DIFF
--- a/recipes-bsp/avnet_boot_scr/avnet-boot-scr.bb
+++ b/recipes-bsp/avnet_boot_scr/avnet-boot-scr.bb
@@ -32,7 +32,7 @@ SRC_URI:pz = " \
             file://avnet_qspi.txt \
             "
 
-SRC_URI_u96v2-sbc = " \
+SRC_URI:u96v2-sbc = " \
             file://avnet_jtag.txt \
             "
 

--- a/recipes-bsp/device-tree/device-tree.bbappend
+++ b/recipes-bsp/device-tree/device-tree.bbappend
@@ -1,13 +1,13 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # Remove avnet-ultra96-rev1 dependency
-YAML_DT_BOARD_FLAGS_u96v2-sbc ?= "{BOARD template}"
+YAML_DT_BOARD_FLAGS:u96v2-sbc ?= "{BOARD template}"
 
 SRC_URI:append = "\
 	file://system-bsp.dtsi \
 "
 
-SRC_URI:append_u96v2-sbc = "\
+SRC_URI:append:u96v2-sbc = "\
 	file://openamp.dtsi \
 "
 
@@ -33,7 +33,7 @@ do_configure:append () {
 }
 
 # For Ultra96-SBC BSP only
-do_configure:append_u96v2-sbc () {
+do_configure:append:u96v2-sbc () {
 	if [ -e ${WORKDIR}/openamp.dtsi ]; then
 		cp ${WORKDIR}/openamp.dtsi ${DT_FILES_PATH}/openamp.dtsi
 		echo '#include "openamp.dtsi"' >> ${DT_FILES_PATH}/${BASE_DTS}.dts

--- a/recipes-core/images/avnet-image-full.inc
+++ b/recipes-core/images/avnet-image-full.inc
@@ -115,9 +115,6 @@ IMAGE_INSTALL:append:minized-sbc = "\
         wpa-supplicant \
 "
 
-IMAGE_INSTALL:append:mz = "\
-"
-
 IMAGE_INSTALL:append:pz = "\
         haveged \
         pciutils \

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -168,4 +168,19 @@ COMMON_FEATURES:append:zynq = "\
         hwcodecs \
         ssh-server-dropbear \
 "
-
+IMAGE_INSTALL:remove:mz = "\
+        hwcodecs \
+        u-boot-tools\
+        sudo \
+        tcf-agent \
+        zstd \
+        util-linux-sulogin \
+        nfs-utils \
+        ncurses-terminfo-base \
+        mtd-utils \
+        iperf3 \
+        e2fsprogs-mke2fs \
+        haveged \
+        bash \
+        ssh-server-dropbear \
+"


### PR DESCRIPTION
Small issue where the override for the u96v2-sbc was not applied due to using the older underscore syntax. This affected the following recipes:

- device-tree.bbappend
- avnet-boot-scr.bb