### PR TITLE
Fix u96v2-sbc missing overrides

### DIFF
--- a/recipes-apps/pmic-prog/pmic-prog.bb
+++ b/recipes-apps/pmic-prog/pmic-prog.bb
@@ -15,7 +15,7 @@ COMPATIBLE_MACHINE = "uz|u96v2-sbc"
 SRC_URI = "git://github.com/Avnet/BSP-rootfs-sources.git;protocol=https;branch=${SRCBRANCH};subpath=${SUBPATH};"
 
 SRC_URI:append:uz = " file://pmic-configs/"
-SRC_URI:append_u96v2-sbc = " file://pmic-configs/"
+SRC_URI:append:u96v2-sbc = " file://pmic-configs/"
 
 SRCREV = "${AUTOREV}"
 
@@ -36,7 +36,7 @@ do_install:append:uz() {
         cp -r ${WORKDIR}/pmic-configs ${D}${ROOT_HOME}/${SUBPATH}/
 }
 
-do_install:append_u96v2-sbc() {
+do_install:append:u96v2-sbc() {
         cp -r ${WORKDIR}/pmic-configs ${D}${ROOT_HOME}/${SUBPATH}/
 }
 

--- a/recipes-bsp/avnet_boot_scr/avnet-boot-scr.bb
+++ b/recipes-bsp/avnet_boot_scr/avnet-boot-scr.bb
@@ -32,7 +32,7 @@ SRC_URI:pz = " \
             file://avnet_qspi.txt \
             "
 
-SRC_URI_u96v2-sbc = " \
+SRC_URI:u96v2-sbc = " \
             file://avnet_jtag.txt \
             "
 

--- a/recipes-bsp/device-tree/device-tree.bbappend
+++ b/recipes-bsp/device-tree/device-tree.bbappend
@@ -1,13 +1,13 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # Remove avnet-ultra96-rev1 dependency
-YAML_DT_BOARD_FLAGS_u96v2-sbc ?= "{BOARD template}"
+YAML_DT_BOARD_FLAGS:u96v2-sbc ?= "{BOARD template}"
 
 SRC_URI:append = "\
 	file://system-bsp.dtsi \
 "
 
-SRC_URI:append_u96v2-sbc = "\
+SRC_URI:append:u96v2-sbc = "\
 	file://openamp.dtsi \
 "
 
@@ -33,7 +33,7 @@ do_configure:append () {
 }
 
 # For Ultra96-SBC BSP only
-do_configure:append_u96v2-sbc () {
+do_configure:append:u96v2-sbc () {
 	if [ -e ${WORKDIR}/openamp.dtsi ]; then
 		cp ${WORKDIR}/openamp.dtsi ${DT_FILES_PATH}/openamp.dtsi
 		echo '#include "openamp.dtsi"' >> ${DT_FILES_PATH}/${BASE_DTS}.dts

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -65,7 +65,7 @@ IMAGE_INSTALL:append:zynqmp = "\
         watchdog-init \
 "
 
-IMAGE_INSTALL:append_u96v2-sbc = "\
+IMAGE_INSTALL:append:u96v2-sbc = "\
         bluez5 \
         connman-gtk \
         git \

--- a/recipes-core/init-ifupdown/init-ifupdown_%.bbappend
+++ b/recipes-core/init-ifupdown/init-ifupdown_%.bbappend
@@ -1,3 +1,3 @@
-FILESEXTRAPATHS:prepend_u96v2-sbc := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:u96v2-sbc := "${THISDIR}/files:"
 
 INITSCRIPT_PARAMS:u96v2-sbc = "start 03 2 3 4 5 . stop 80 0 6 1 ."

--- a/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -6,7 +6,7 @@ SRC_URI += "file://bsp.cfg \
             file://0001-hwmon-pmbus-Add-Infineon-IR38060-62-63-driver.patch \
             "
 
-SRC_URI:append_u96v2-sbc = " file://fix_u96v2_pwrseq_simple.patch \
+SRC_URI:append:u96v2-sbc = " file://fix_u96v2_pwrseq_simple.patch \
                            "
 
 #SRC_URI:append:mz = " file://0001-irqchip-irq-xilinx-intc-use-version-from-4.19.patch \


### PR DESCRIPTION
The u96v2-sbc machine overrides were not converted to the new `:` override syntax. This PR simply corrects this.  