### PR TITLE
UltraZed-EG IO Board PetaLinux 2022.1

### DIFF
--- a/conf/machine/uz3eg-iocc.conf
+++ b/conf/machine/uz3eg-iocc.conf
@@ -21,8 +21,6 @@ SPL_BINARY ?= ""
 
 SERIAL_CONSOLES ?= "115200;ttyPS0"
 
-KERNEL_DEVICETREE = "xilinx/zynqmp-zcu102-rev1.0.dtb"
-
 EXTRA_IMAGEDEPENDS += " \
 		arm-trusted-firmware \
 		virtual/bootloader \

--- a/recipes-apps/blinky-systemd/blinky-systemd.bb
+++ b/recipes-apps/blinky-systemd/blinky-systemd.bb
@@ -1,0 +1,31 @@
+#
+# This file is the blinky-systemd recipe.
+#
+
+SUMMARY = "Systemd service unit file for sample blinky application"
+SECTION = "PETALINUX/apps"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "uz"
+
+SRC_URI = "file://blinky.service \
+		   file://run-blinky.sh \
+	"
+
+inherit systemd
+
+RDEPENDS:${PN} += "blinky gpio-utils-systemd"
+
+do_install() {
+	install -d ${D}/${systemd_system_unitdir}
+	install -m 0744 ${WORKDIR}/blinky.service ${D}${systemd_system_unitdir}/blinky.service
+
+	install -d ${D}/home/root/
+	install -m 0755 ${WORKDIR}/run-blinky.sh ${D}/home/root/run-blinky.sh
+}
+
+SYSTEMD_SERVICE:${PN} = "blinky.service"
+
+FILES:${PN} += "${systemd_system_unitdir}/blinky.service \
+				/home/root/run-blinky.sh \"

--- a/recipes-apps/blinky-systemd/files/blinky.service
+++ b/recipes-apps/blinky-systemd/files/blinky.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Blinky Sample Application
+Requires=gpio-utils.service
+After=gpio-utils.service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /home/root/run-blinky.sh
+StandardOutput=tty
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-apps/blinky-systemd/files/run-blinky.sh
+++ b/recipes-apps/blinky-systemd/files/run-blinky.sh
@@ -1,0 +1,71 @@
+# ----------------------------------------------------------------------------
+#
+#        ** **        **          **  ****      **  **********  **********
+#       **   **        **        **   ** **     **  **              **
+#      **     **        **      **    **  **    **  **              **
+#     **       **        **    **     **   **   **  *********       **
+#    **         **        **  **      **    **  **  **              **
+#   **           **        ****       **     ** **  **              **
+#  **  .........  **        **        **      ****  **********      **
+#     ...........
+#                                     Reach Further
+#
+# ----------------------------------------------------------------------------
+# 
+#  This design is the property of Avnet.  Publication of this
+#  design is not authorized without written consent from Avnet.
+# 
+#  Please direct any questions to the community support forum:
+#     http://www.ultrazed.org/forum
+# 
+#  Product information is available at:
+#     http://www.ultrazed.org/
+# 
+#  Disclaimer:
+#     Avnet, Inc. makes no warranty for the use of this code or design.
+#     This code is provided  "As Is". Avnet, Inc assumes no responsibility for
+#     any errors, which may appear in this code, nor does it make a commitment
+#     to update the information contained herein. Avnet, Inc specifically
+#     disclaims any implied warranties of fitness for a particular purpose.
+#                      Copyright(c) 2016 Avnet, Inc.
+#                              All rights reserved.
+# 
+# ----------------------------------------------------------------------------
+# 
+#  Create Date:         July 25, 2022
+#  Design Name:         LED "Blinky" Application Daemon Launcher
+#  Module Name:         run-blinky(.sh)
+#  Project Name:        LED "Blinky" Application
+#  Target Devices:      Xilinx Zynq and Zynq UltraScale+ MPSoC
+#  Hardware Boards:     UltraZed-EV + EV Carrier
+# 
+#  Tool versions:       Xilinx PetaLinux 2022.1
+# 
+#  Description:         Script to launch "Blinky" LED App
+# 
+#  Dependencies:        
+#
+#  Revision:            July 25, 2022: 1.0 Initial version
+# 
+# ----------------------------------------------------------------------------
+#!/bin/sh
+
+DAEMON=/home/root/blinky
+#This script launches the application that will blink an LED mapped to
+#the Zynq or ZynqMP PS MIO
+#In this case the PS LED is mapped to MIO26
+source /usr/local/bin/gpio/gpio_common.sh
+PS_LED1=$(get_gpio PS_LED1)
+DAEMON_OPTS="-g $PS_LED1"
+
+# Show the application banner.
+echo " "
+echo "*********************************************************************"
+echo "***                                                               ***"
+echo "***   Avnet UltraZed Out Of Box PetaLinux Build V1.2              ***"
+echo "***   The PS LED is mapped to $PS_LED1                            ***"
+echo "***                                                               ***"
+echo "*********************************************************************"
+echo " "
+
+$DAEMON $DAEMON_OPTS

--- a/recipes-apps/python-webserver-systemd/files/python-webserver.service
+++ b/recipes-apps/python-webserver-systemd/files/python-webserver.service
@@ -1,11 +1,14 @@
 [Unit]
 Description=Python Webserver
 Requires=network-online.target
-After=network-online.target 
+After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/bin/bash /home/root/webserver/launch_server.sh
+ExecStartPre=/bin/bash -c 'source /usr/local/bin/gpio/gpio_common.sh && export_gpio_map'
+ExecStart=python3 /home/root/webserver/server.py
+WorkingDirectory=/home/root/webserver
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-apps/python-webserver-systemd/files/python-webserver.service
+++ b/recipes-apps/python-webserver-systemd/files/python-webserver.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Python Webserver
+Requires=network-online.target
+After=network-online.target 
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /home/root/webserver/launch_server.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-apps/python-webserver-systemd/python-webserver-systemd.bb
+++ b/recipes-apps/python-webserver-systemd/python-webserver-systemd.bb
@@ -1,0 +1,22 @@
+#
+# This file is the python-webserver-systemd recipe.
+#
+
+SUMMARY = "Simple python-webserver-systemd application"
+SECTION = "PETALINUX/apps"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://python-webserver.service"
+
+inherit systemd
+
+do_install() {
+	install -d ${D}/${systemd_system_unitdir}
+	install -m 0744 ${WORKDIR}/python-webserver.service ${D}${systemd_system_unitdir}/python-webserver.service
+}
+
+SYSTEMD_SERVICE:${PN} = "python-webserver.service"
+
+FILES:${PN} += "${systemd_system_unitdir}/python-webserver.service"
+

--- a/recipes-apps/python-webserver-systemd/python-webserver-systemd.bb
+++ b/recipes-apps/python-webserver-systemd/python-webserver-systemd.bb
@@ -9,11 +9,13 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://python-webserver.service"
 
+RDEPENDS:${PN} += "bash python3-core python-webserver gpio-utils-systemd"
+
 inherit systemd
 
 do_install() {
 	install -d ${D}/${systemd_system_unitdir}
-	install -m 0744 ${WORKDIR}/python-webserver.service ${D}${systemd_system_unitdir}/python-webserver.service
+	install -m 0644 ${WORKDIR}/python-webserver.service ${D}${systemd_system_unitdir}/python-webserver.service
 }
 
 SYSTEMD_SERVICE:${PN} = "python-webserver.service"

--- a/recipes-core/images/avnet-image-full.inc
+++ b/recipes-core/images/avnet-image-full.inc
@@ -86,7 +86,7 @@ IMAGE_INSTALL:append:uz7ev-evcc = "\
 
 IMAGE_INSTALL:remove:uz7ev-evcc-hdmi = "\
         blinky \
-        blinky-init \
+        blinky-systemd \
         user-switch-test \
 "
 

--- a/recipes-core/images/avnet-image-full.inc
+++ b/recipes-core/images/avnet-image-full.inc
@@ -38,6 +38,10 @@ IMAGE_INSTALL:append:zynq = "\
         ncurses-terminfo-base \
 "
 
+# Removed packagegroup-petalinux-vitisai-dev packagegroup-petalinux-vitisai from zynqmp image install due to
+# the providing layer (meta-vitis-ai https://github.com/Xilinx/meta-vitis-ai) not being compatible with 2021.2 and
+# Yocto honister yet.
+
 IMAGE_INSTALL:append:zynqmp = "\
         bridge-utils \
         cmake \
@@ -61,8 +65,6 @@ IMAGE_INSTALL:append:zynqmp = "\
         packagegroup-petalinux-python-modules \
         packagegroup-petalinux-self-hosted \
         packagegroup-petalinux-v4lutils \
-        packagegroup-petalinux-vitisai-dev \
-        packagegroup-petalinux-vitisai \
         packagegroup-petalinux-x11 \
         pciutils \
         python3-pyserial \

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -79,7 +79,7 @@ IMAGE_INSTALL:append:u96v2-sbc = "\
 
 IMAGE_INSTALL:append:uz = "\
         blinky \
-        blinky-init \
+        blinky-systemd \
         libdrm \
         libdrm-kms \
         libdrm-tests \

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -89,7 +89,7 @@ IMAGE_INSTALL:append:uz = "\
         pciutils \
         performance-tests \
         python-webserver \
-        python-webserver-init \
+        python-webserver-systemd \
         python3 \
         python3-core \
         python3-dbus \
@@ -109,7 +109,7 @@ IMAGE_INSTALL:append:uz7ev-evcc-hdmi-v-n = "\
 
 IMAGE_INSTALL:remove:uz7ev-evcc-hdmi = "\
         python-webserver \
-        python-webserver-init \
+        python-webserver-systemd \
         user-led-test \
 "
 

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -49,7 +49,6 @@ IMAGE_INSTALL:append:zynqmp = "\
         util-linux-fdisk \
         util-linux-mount \
         util-linux-mkfs \
-        watchdog-init \
 "
 
 IMAGE_INSTALL:append:u96v2-sbc = "\

--- a/recipes-utils/gpio-utils-systemd/files/gpio-utils.service
+++ b/recipes-utils/gpio-utils-systemd/files/gpio-utils.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Common GPIO Utilities
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/local/bin/gpio/gpio_map.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-utils/gpio-utils-systemd/gpio-utils-systemd.bb
+++ b/recipes-utils/gpio-utils-systemd/gpio-utils-systemd.bb
@@ -1,0 +1,23 @@
+#
+# This file is the gpio-utils-systemd recipe.
+#
+
+SUMMARY = "systemd service which initializes the gpio map"
+SECTION = "PETALINUX/utils"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://gpio-utils.service"
+
+inherit systemd
+
+RDEPENDS:${PN} += "gpio-utils"
+
+do_install() {
+	install -d ${D}/${systemd_system_unitdir}
+	install -m 0744 ${WORKDIR}/gpio-utils.service ${D}${systemd_system_unitdir}/gpio-utils.service
+}
+
+SYSTEMD_SERVICE:${PN} = "gpio-utils.service"
+
+FILES:${PN} += "${systemd_system_unitdir}/gpio-utils.service"

--- a/recipes-utils/gpio-utils/files/Makefile
+++ b/recipes-utils/gpio-utils/files/Makefile
@@ -9,7 +9,7 @@ VERSION = $(MAJOR).$(MINOR)
 
 all: lib$(NAME).so
 lib$(NAME).so.$(VERSION): $(OUTS)
-	$(CC) $(LDFLAGS) $(OUTS) -shared -Wl,-soname,lib$(NAME).so.$(MAJOR) -o lib$(NAME).so.$(VERSION)
+	$(CC) $(CFlAGS) $(LDFLAGS) $(OUTS) -shared -Wl,-soname,lib$(NAME).so.$(MAJOR) -o lib$(NAME).so.$(VERSION)
 
 lib$(NAME).so: lib$(NAME).so.$(VERSION)
 	rm -f lib$(NAME).so.$(MAJOR) lib$(NAME).so
@@ -17,7 +17,7 @@ lib$(NAME).so: lib$(NAME).so.$(VERSION)
 	ln -s lib$(NAME).so.$(MAJOR) lib$(NAME).so
 
 %.o: %.cpp
-	$(CXX) $(LDFLAGS) -c -o $(NAME).o $(LIBSOURCES)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -c -o $(NAME).o $(LIBSOURCES)
 
 clean:
 	rm -rf *.o *.so *.so.*

--- a/recipes-utils/gpio-utils/gpio-utils.bb
+++ b/recipes-utils/gpio-utils/gpio-utils.bb
@@ -22,6 +22,8 @@ S = "${WORKDIR}"
 
 RDEPENDS:${PN} += "gpio-utils-init"
 
+CXXFLAGS:aarch64 = "-fPIC"
+
 do_install() {
 
     INSTALL_DIR=${D}${prefix}/local/bin/gpio


### PR DESCRIPTION
Changes required to get PetaLinux 2022.1 running on the UltraZed EG IO Board (uz3eg_iocc). 

**Changes**

- GPIO Utils compilation flags updated with the `-fPIC` (Position Independent Code) value as previously when building for aarm64 would result in failure during building.  
- Removed `packagegroup-petalinux-vitisai` from the the `avnet-image-full` image due to this Yocto layer not having been ported to PetaLinux 2022.1 (Honister) yet by Xilinx.
- Added a `python-webserver-systemd` recipe which installs a systemd service to run the basic webserver. 
- Added a `blinky-systemd` recipe which installs a systemd service to run the blinky LED program on boot of the board. 
