### PR TITLE
Fix Zynq UltraScale avnet-boot Script Image Deploy 

### DIFF
--- a/conf/machine/minized-sbc.conf
+++ b/conf/machine/minized-sbc.conf
@@ -33,4 +33,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/mz7010-som.conf
+++ b/conf/machine/mz7010-som.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/mz7020-som.conf
+++ b/conf/machine/mz7020-som.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/pz7010-fmc2.conf
+++ b/conf/machine/pz7010-fmc2.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/pz7015-fmc2.conf
+++ b/conf/machine/pz7015-fmc2.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/pz7020-fmc2.conf
+++ b/conf/machine/pz7020-fmc2.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/pz7030-fmc2.conf
+++ b/conf/machine/pz7030-fmc2.conf
@@ -36,4 +36,4 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "

--- a/conf/machine/u96v2-sbc.conf
+++ b/conf/machine/u96v2-sbc.conf
@@ -39,7 +39,7 @@ IMAGE_BOOT_FILES = " \
                     "
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware-wl18xx"
 

--- a/conf/machine/uz3eg-iocc.conf
+++ b/conf/machine/uz3eg-iocc.conf
@@ -41,7 +41,7 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"
 

--- a/conf/machine/uz3eg-pciec.conf
+++ b/conf/machine/uz3eg-pciec.conf
@@ -43,7 +43,7 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"
 

--- a/conf/machine/uz7ev-evcc-hdmi-v-n.conf
+++ b/conf/machine/uz7ev-evcc-hdmi-v-n.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc-hdmi-v.conf
+++ b/conf/machine/uz7ev-evcc-hdmi-v.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc-hdmi.conf
+++ b/conf/machine/uz7ev-evcc-hdmi.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc-nvme.conf
+++ b/conf/machine/uz7ev-evcc-nvme.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc-quadcam-h-v.conf
+++ b/conf/machine/uz7ev-evcc-quadcam-h-v.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc-quadcam-h.conf
+++ b/conf/machine/uz7ev-evcc-quadcam-h.conf
@@ -43,6 +43,6 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"

--- a/conf/machine/uz7ev-evcc.conf
+++ b/conf/machine/uz7ev-evcc.conf
@@ -43,7 +43,7 @@ PMU_FIRMWARE_IMAGE_NAME ?= "pmu-firmware-zynqmp-pmu"
 PMU_FIRMWARE_DEPLOY_DIR ?= "${TOPDIR}/pmutmp/deploy/images/zynqmp-pmu"
 
 # deploy avnet-boot-scr scripts in images/linux/ folder
-EXTRA_FILESLIST += " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
+EXTRA_FILESLIST:append = " ${DEPLOY_DIR_IMAGE}/avnet-boot/:avnet-boot/ "
 
 EXTRA_IMAGEDEPENDS:remove = "qemu-devicetrees"
 


### PR DESCRIPTION
Xilinx have put in their own =? (default assignment) for the `EXTRA_FILESLIST` variable (_See plnx_deploy.bbclass https://github.com/Xilinx/meta-petalinux/blob/master/classes/plnx-deploy.bbclass_)   

This overwrote our += (append) for the `EXTRA_FILESLIST` within each Zynq UltraScale machine. This copied  the `avnet-boot` compiled U-Boot boot scripts to the PetaLinux image directory. The boot scripts not being copied caused some of the scripts in the Avnet PetaLinux repository unable to flash SOM's via JTAG. 

The change is to use the the `:append` instead of `+=` as it doesn't  doesn't get immediately evaluated and is evaluated at the same time as the default assignment. 

