### PR TITLE
Add avnet-image-factest for zub1cg-sbc factest design

### DIFF
--- a/recipes-core/images/avnet-image-factest.bb
+++ b/recipes-core/images/avnet-image-factest.bb
@@ -2,3 +2,4 @@ DESCRIPTION = "Factest image definition for Avnet boards"
 LICENSE = "MIT"
 
 require avnet-image-factest.inc
+

--- a/recipes-core/images/avnet-image-factest.bb
+++ b/recipes-core/images/avnet-image-factest.bb
@@ -1,0 +1,4 @@
+DESCRIPTION = "Factest image definition for Avnet boards"
+LICENSE = "MIT"
+
+require avnet-image-factest.inc

--- a/recipes-core/images/avnet-image-factest.inc
+++ b/recipes-core/images/avnet-image-factest.inc
@@ -1,5 +1,9 @@
 require recipes-core/images/avnet-image-minimal.inc
 
-IMAGE_INSTALL:append:zub1cg-sbc = "\
+COMPATIBLE_MACHINE = "zub1cg-sbc"
+
+IMAGE_INSTALL:append = "\
         factest \
 "
+
+

--- a/recipes-core/images/avnet-image-factest.inc
+++ b/recipes-core/images/avnet-image-factest.inc
@@ -1,0 +1,5 @@
+require recipes-core/images/avnet-image-minimal.inc
+
+IMAGE_INSTALL:append:zub1cg-sbc = "\
+        factest \
+"

--- a/recipes-core/images/avnet-image-factest.wks
+++ b/recipes-core/images/avnet-image-factest.wks
@@ -1,0 +1,6 @@
+# short-description: Create EMMC image with a boot partition
+# long-description: Creates a partitioned EMMC image. Boot files
+# are located in the first vfat partition.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4 --fixed-size 1G
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4

--- a/recipes-core/images/avnet-image-minimal.inc
+++ b/recipes-core/images/avnet-image-minimal.inc
@@ -125,7 +125,6 @@ IMAGE_INSTALL:append:pz = "\
 "
 
 IMAGE_INSTALL:append:zub1cg-sbc = "\
-        factest \
         blinky \
         blinky-systemd \
         libdrm \


### PR DESCRIPTION
To allow us not to include the Factory Test Scripts within the standard set of user targeted images for the zub1cg-sbc, I've created `avnet-image-factest` image recipe which inherits the `avnet-image-minimal` image but adds the `factest` script to the image install.  

**User Targeted Images**
- zub1cg_sbc_base
- zub1cg_sbc_dualcam
- zub1cg_sbc_valtest