### PR TITLE
Fix missing SATA controller parameters in device trees for UltraZed-EG

### DIFF
--- a/recipes-bsp/device-tree/files/uz3eg-iocc/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/uz3eg-iocc/system-bsp.dtsi
@@ -204,5 +204,15 @@
    phy-names = "sata-phy";
    /* <psgtr_phandle> <lane_number> <controller_type> <instance> <refclk> */
    phys = <&psgtr 1 PHY_TYPE_SATA 1 1>;
+
+   /* Missing SATA controller parameters not included in 2022.2 generated Xilinx device trees */
+   ceva,p0-burst-params = /bits/ 8 <0x13 0x08 0x4A 0x06>;
+   ceva,p0-cominit-params = /bits/ 8 <0x18 0x40 0x18 0x28>;
+   ceva,p0-comwake-params = /bits/ 8 <0x06 0x14 0x08 0x0E>;
+   ceva,p0-retry-params = /bits/ 16 <0x96A4 0x3FFC>;
+   ceva,p1-burst-params = /bits/ 8 <0x13 0x08 0x4A 0x06>;
+   ceva,p1-cominit-params = /bits/ 8 <0x18 0x40 0x18 0x28>;
+   ceva,p1-comwake-params = /bits/ 8 <0x06 0x14 0x08 0x0E>;
+   ceva,p1-retry-params = /bits/ 16 <0x96A4 0x3FFC>;
 };
 

--- a/recipes-bsp/device-tree/files/uz3eg-pciec/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/uz3eg-pciec/system-bsp.dtsi
@@ -204,5 +204,15 @@
    phy-names = "sata-phy";
    /* <psgtr_phandle> <lane_number> <controller_type> <instance> <refclk> */
    phys = <&psgtr 1 PHY_TYPE_SATA 1 1>;
+
+   /* Missing SATA controller parameters not included in 2022.2 generated Xilinx device trees */
+   ceva,p0-burst-params = /bits/ 8 <0x13 0x08 0x4A 0x06>;
+   ceva,p0-cominit-params = /bits/ 8 <0x18 0x40 0x18 0x28>;
+   ceva,p0-comwake-params = /bits/ 8 <0x06 0x14 0x08 0x0E>;
+   ceva,p0-retry-params = /bits/ 16 <0x96A4 0x3FFC>;
+   ceva,p1-burst-params = /bits/ 8 <0x13 0x08 0x4A 0x06>;
+   ceva,p1-cominit-params = /bits/ 8 <0x18 0x40 0x18 0x28>;
+   ceva,p1-comwake-params = /bits/ 8 <0x06 0x14 0x08 0x0E>;
+   ceva,p1-retry-params = /bits/ 16 <0x96A4 0x3FFC>;
 };
 


### PR DESCRIPTION
The XST generated Device Tree by the Vivado/PetaLinux doesn't contain the burst and retry parameters required for the SATA controller to properly function. This is just a change in 2022.2 which is probably a bug. Therefore, I think if we just add it into the `meta-avnet` layer to get required functionality until fixed. 

I haven't tested this yet on the UltraZed-EV board yet. But I predict that the issue will be there as well. 