### PR TITLE
recipes-bsp: device-tree: add dp-emmc syzygy board by default in zu1 …

### DIFF
--- a/recipes-bsp/device-tree/files/zub1cg-sbc/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/zub1cg-sbc/system-bsp.dtsi
@@ -7,16 +7,23 @@
 / {
    chosen {
       bootargs = "earlycon console=ttyPS0,115200 clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait cma=512M";
+      xlnx,eeprom= &mac_eeprom;
    };
 
    xlnk {
       compatible = "xlnx,xlnk-1.0";
    };
 
-   chosen {
-      xlnx,eeprom= &mac_eeprom;
+   aliases {
+      mmc0 = &sdhci1;
+      mmc1 = &sdhci0;
    };
 
+   gtr_clk0: gtr_clk0 { /* gtr_refclk0_dp - 135MHz */
+      compatible = "fixed-clock";
+      #clock-cells = <0>;
+      clock-frequency = <135000000>;
+   };
 };
 
 &gem2 {
@@ -80,4 +87,10 @@
       compatible = "atmel,24mac402";
       reg = <0x58>;
    };
+};
+
+&psgtr {
+   /* DP */
+   clocks = <&gtr_clk0>;
+   clock-names = "ref0";
 };


### PR DESCRIPTION
…designs

Add support for the DP-EMMC SYZYGY extension board, added by default in the zu1 FPGA designs (connector J2)