### PR TITLE
Fix initializing mac address  from eeprom bug on zuboard (zub1cg)

### DIFF
--- a/recipes-bsp/device-tree/files/zub1cg-sbc/system-bsp.dtsi
+++ b/recipes-bsp/device-tree/files/zub1cg-sbc/system-bsp.dtsi
@@ -7,7 +7,7 @@
 / {
    chosen {
       bootargs = "earlycon console=ttyPS0,115200 clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait cma=512M";
-      nvmem = &mac_eeprom;
+      nvmem0 = &eui_eepromm;
    };
 
    xlnk {
@@ -33,6 +33,8 @@
 &gem2 {
    status = "okay";
    phy-mode = "rgmii-id";
+   
+   /delete-property/ local-mac-address;
    nvmem-cells = <&mac_address>;
    nvmem-cell-names = "mac-address";
 
@@ -89,13 +91,13 @@
    #address-cells = <1>;
    #size-cells = <0>;
    /* Ethernet MAC ID EEPROM */
-   mac_eeprom: mac_eeprom@58 { /* U7 */
+   eui_eeprom: eui_eeprom@58 { /* U7 */
       #address-cells = <1>;
       #size-cells = <1>;
       compatible = "atmel,24mac402";
       reg = <0x58>;
-      mac_address: mac-address@9A {
-         reg = <0x9A 0x06>;
+      mac_address: mac_address@9A {
+         reg = <0x9A 0x6>;
       };
    };
 };


### PR DESCRIPTION
Hi,

I found that the u-boot cannot obtain the mac address from EEPROM on zuboard.

Here is my fix.

I have tested this modification on Xilinx SDT workflow with XSCT 2024.2 (from vivado 2024.2) and I build the yocto system  to test with it.
XSCT version: 2024.2
meta-xilinx version: rel-v2024.2
yocto version: scarthgap

Test result:
![image](https://github.com/user-attachments/assets/26f3560a-3c97-4d4d-b2f5-7fedfc3c80ab)
