### PR TITLE
Disabled persistent network interface naming on the picozed boards.

### DIFF
--- a/recipes-bsp/avnet_boot_scr/files/pz/avnet_mmc_ext4.txt
+++ b/recipes-bsp/avnet_boot_scr/files/pz/avnet_mmc_ext4.txt
@@ -5,11 +5,11 @@
 ################
 
 echo Trying to boot from SD...
-setenv bootargs "console=ttyPS0,115200 earlycon root=/dev/mmcblk0p2 rw rootwait"
+setenv bootargs "console=ttyPS0,115200 earlycon root=/dev/mmcblk0p2 rw rootwait net.ifnames=0"
 fatload mmc 0:1 0x4000000 image.ub
 bootm 0x04000000
 
 echo Trying to boot from EMMC...
-setenv bootargs "console=ttyPS0,115200 earlycon root=/dev/mmcblk1p2 rw rootwait"
+setenv bootargs "console=ttyPS0,115200 earlycon root=/dev/mmcblk1p2 rw rootwait net.ifnames=0"
 fatload mmc 1:1 0x4000000 image.ub
 bootm 0x04000000


### PR DESCRIPTION
This is to allow Network interface names to continue to be named as eth0, etc instead of persistent names.

In the latest 2024.2 update persistent names in the form of enp<mac_address> are used for naming network interfaces.  Previous versions used eth0, etc.  The /etc/network/interfaces configuration file uses the old naming format of eth0 and doesn't appear to support wildcards to handle mac addresses embedded in the network interface name.  This naming change prevented the rules to start the dhcp client on eth0 from working.

The behavior now remains the same as in previous versions,  if an Ethernet cable is connected at boot, it will try to acquire an IP address using the dhcp client.  If that fails, the network interface has to be brought down,  the ip address set manually and then brought up again.
